### PR TITLE
Updated get_cartesian() with ability to obtain Observer tables.

### DIFF
--- a/horizon/interface.py
+++ b/horizon/interface.py
@@ -289,8 +289,10 @@ class Interface():
         self.telnet.write("y\n")
 
         # select reference plane: body, eclip, frame
-        self.telnet.read_until(HORIZON_MISC_PROMPT)
-        self.telnet.write("body\n")
+        # (This is not needed for HORIZON_OBSERVE reqs)
+        if type is not HORIZON_OBSERVE:
+            self.telnet.read_until(HORIZON_MISC_PROMPT)
+            self.telnet.write("body\n")
 
         self.telnet.read_until(HORIZON_MISC_PROMPT)
         self.telnet.write("{0}\n".format(start))
@@ -304,6 +306,12 @@ class Interface():
         # accept output
         self.telnet.read_until(HORIZON_MISC_PROMPT)
         self.telnet.write("\r\n")
+
+        # select table quantities
+        # (only for HORIZON_OBSERVE)
+        if type is HORIZON_OBSERVE:
+            self.telnet.read_until(HORIZON_MISC_PROMPT)
+            self.telnet.write("A\n")
 
         result = self.telnet.read_until(HORIZON_CARTESIAN_PROMPT)
 


### PR DESCRIPTION
Hey,

I'm working on a project that needs to pull orbital elements and observer table data from the Horizons system.  The system will be integrated into the Skynet Robotic Telescope Network at UNC Chapel Hill for use in tracking Near Earth Objects.  I make a few simple changes to your get_cartesian() function so that it can pull observer tables from the telnet interface and wanted to send them back your way in case you're interested.

Thanks,

Andrew
